### PR TITLE
Add option to build static cli tool

### DIFF
--- a/subprojects/ce-login/README.md
+++ b/subprojects/ce-login/README.md
@@ -9,13 +9,52 @@ meson setup -Dlib=false -Dbin=true build
 ninja -C build
 ```
 
+To build the ce-login static utility openssl and json-c will need to be statically compiled:
+
+Openssl static build example:
+```
+git clone https://github.com/openssl/openssl.git
+cd openssl
+OPENSSL_INSTALL_DIR=$PWD/install
+./Configure no-sock no-threads no-shared no-stdio no-dso --prefix=$OPENSSL_INSTALL_DIR --openssldir=$PWD/ssl
+THREADS=$(grep -c   "^processor" /proc/cpuinfo)
+make -j$(THREADS)
+make install -j$(THREADS)
+```
+Json-c static build example:
+```
+git clone https://github.com/json-c/json-c
+cd json-c
+JSON_DIR=$PWD
+mkdir install
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=$JSON_DIR/install
+THREADS=$(grep -c   "^processor" /proc/cpuinfo)
+make -j$(THREADS)
+make install -j$(THREADS)
+```
+Note: PKG_CONFIG_PATH needs to be set if dependencies openssl and json-c are not statically
+    compiled and not installed in the standard location
+
+Otherwise, you should be able to run the next command without setting the PKG_CONFIG_PATH env var
+```
+PKG_CONFIG_PATH=$JSON_DIR:$OPENSSL_INSTALL_DIR/lib64/pkgconfig/ \
+    meson setup -Dlib=false -Dstatic-bin=true build
+ninja -C build
+```
+
+Check that celogin_cli utility is statically compiled:
+```
+ldd ./build/celogin_cli
+>   not a dynamic executable
+```
+
 There is support to build either the cli utility, static lib or shared lib.
 
 The options can be configured on setup or afterwards with the 'meson configure' command
 
 Set any of the options to 'true' to build desired target
 ```
-meson configure -Dlib=[true | false] -Dbin=[true | false] -Ddefault_library=[shared | static] build
+meson configure -Dlib=[true | false] -Dbin=[true | false] -Dstatic-bin=[true | false] -Ddefault_library=[shared | static] build
 ```
 Default configuration is:
 ```
@@ -23,12 +62,16 @@ Default configuration is:
 ```
 As defined by meson_options.txt
 
-Running unit tests:
+Running meson unit tests:
 ```
 meson setup -Dlib=false -Dbin=true build
 ninja -C build
 cd build
 meson test
+```
+Running celogin_cli unit tests:
+```
+./build/celogin_cli test
 ```
 
 Example creation of pub/priv keys for this utility:
@@ -46,40 +89,36 @@ Get private key
 openssl rsa -in rsaprivkey.pem -outform DER -out rsaprivkey.der
 ```
 
-Example usage of this utility:
+Example usage of the celogin_cli utility:
 
 Create ACF:
 ```
-./celogin_cli create \
-                --machine 'P10,dev,12345' \
-                --sourceFileName "none" \
+./build/celogin_cli create \
+                --machine 'P10,dev,UNSET' \
                 --password "0penBmc" \
                 --expirationDate "2025-12-25" \
-                --requestId "1234" \
-                --pkey ../p10-celogin-lab-pkey.der \
-                --output ./service.acf \
+                --pkey ./p10-celogin-lab-pkey.der \
+                --output ./service.acf
 ```
 
 Verify ACF:
 ```
-./celogin_cli verify \
+./build/celogin_cli verify \
                 --hsfFile ./service.acf \
-                --publicKeyFile ../p10-celogin-lab-pub.der \
+                --publicKeyFile ./p10-celogin-lab-pub.der \
                 --password "0penBmc" \
-                --serialNumber "12345"
+                --serialNumber "UNSET"
 ```
 
 Decode ACF - Decodes and prints contents of ACF:
 ```
-./celogin_cli decode \
+./build/celogin_cli decode \
                 --hsfFile ./service.acf \
-                --publicKeyFile ../p10-celogin-lab-pub.der
+                --publicKeyFile ./p10-celogin-lab-pub.der
 ```
 
 Supported keyword value pairs:
 
 machine: [ ProcessorGeneration (P10), ServiceAuthority (ce | dev), SerialNumber ( "UNSET" | bmc serial number )]\
-requestId: [unrestricted]\
-sourceFileName: [unrestricted]\
 expirationDate: [yyyy-mm-dd format only]\
 password: [unrestricted]

--- a/subprojects/ce-login/meson.build
+++ b/subprojects/ce-login/meson.build
@@ -73,6 +73,19 @@ if get_option('lib')
   install_headers('celogin/include/CeLogin.h', 'celogin/src/CeLoginAsnV1.h', 'celogin/src/CeLoginUtil.h', 'celogin/src/JsmnUtils.h', 'celogin/src/CeLoginJson.h')
 endif
 
+if get_option('static-bin')
+  #If openssl/json-c static libraries are not installed you must build them
+  #https://github.com/openssl/openssl
+  #https://github.com/json-c/json-c
+  #Once built you can configure the location of the pkg-config files by setting PKG_CONFIG_PATH env variable
+  #Check README.md for static compilation examples
+  libjson_c = dependency('json-c', required : true, static : true)
+  libcrypto = dependency('libcrypto', required : false, static : true)
+  libssl = dependency('libssl', required : false, static : true)
+  cli_deps = [ jsmn, libjson_c, libcrypto, libssl]
+  exe = executable('celogin_cli', cpp_args : args, link_args : ['-static'] ,sources : all_srcs, dependencies : cli_deps, include_directories : [inc_dir]  )
+endif
+
 #Ce-login utility for generating access control files
 if get_option('bin')
 

--- a/subprojects/ce-login/meson_options.txt
+++ b/subprojects/ce-login/meson_options.txt
@@ -1,2 +1,3 @@
 option('lib', type : 'boolean', value : true, description : 'Build the static object by default')
 option('bin', type : 'boolean', value : false, description : 'Do not build the binary by default')
+option('static-bin', type : 'boolean', value : false, description : 'Do not build the static binary by default')


### PR DESCRIPTION
User must statically compile openssl and json-c
    to use this option

Updated README.md for instructions to statically
    compile cli utility