### PR TITLE
pam_ibmacf Handle blank serial number

### DIFF
--- a/src/pam_ibmacf.cpp
+++ b/src/pam_ibmacf.cpp
@@ -29,6 +29,7 @@
 
 #define SOURCE_FILE_VERSION 1
 #define UNSET_SERIAL_NUM_KEYWORD "UNSET"
+#define BLANK_SERIAL_NUMBER "       "
 
 //RUN_UNIT_TESTS should only be enabled when running
 //meson unit tests, otherwise this shoudn't be enabled
@@ -390,7 +391,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc,
         DBUS_SERIAL_NUM_PROP, pamh);
 #endif
     // If serial number is empty on machine set as UNSET for check with acf
-    if (mSerialNumber.empty())
+    if (mSerialNumber.empty() || (mSerialNumber == BLANK_SERIAL_NUMBER))
     {
         mSerialNumber = UNSET_SERIAL_NUM_KEYWORD;
     }


### PR DESCRIPTION
This enhances the pam_ibmacf module authentication function to recognize a serial number of 7 blanks as an UNSET serial number.

Tested: Partially
Tested with an empty serial number and non-blank serial number.
Not tested with the 7-blanks serial number.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>