### PR TITLE
jsmn: utilize local file if available

### DIFF
--- a/subprojects/ce-login/meson.build
+++ b/subprojects/ce-login/meson.build
@@ -9,6 +9,7 @@ project(
         'cpp_std=c++11'
     ]
 )
+cpp = meson.get_compiler('cpp')
 
 #dependencies
 cxx = meson.get_compiler('cpp')
@@ -53,8 +54,12 @@ else
     endif
 endif
 
-#Fetches jsmn header library
-jsmn = dependency('jsmn', required : true, fallback : ['jsmn', 'jsmn_dep'])
+#Fetches jsmn header library if not found
+if cpp.has_header('jsmn.h')
+    jsmn = declare_dependency()
+else
+    jsmn = dependency('jsmn', required : true, fallback : ['jsmn', 'jsmn_dep'])
+endif
 lib_deps = [ libcrypto, libssl, jsmn ]
 
 #includes


### PR DESCRIPTION
Within bitbake env, we want to use the installed jsmn.h if it's available.

Downstream only code, I verified I could build this within bitbake using a new jsmn.bb recipe to pull the header into the bitbake (and avoid having meson try to auto pull the repo down).

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>