### PR TITLE
Add support for ACF V2 and targeted ACF.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,5 +72,10 @@ else
   libcelogin_dep = sp.get_variable('lib_ce_login_dep')
   deps = [sdbusplus, libcrypto, libssl, libcelogin_dep, pam]
 
-  library('pam_ibmacf', 'src/pam_ibmacf.cpp', pic : true, name_prefix : '', dependencies : deps, install : true, install_dir : '/lib/security')
+  # sub directores may add source files and include directoies
+  sources = []
+  incdir = []
+  subdir('src')
+
+  library('pam_ibmacf', sources, include_directories : incdir, pic : true, name_prefix : '', dependencies : deps, install : true, install_dir : '/lib/security')
 endif

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,117 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction:   false
+  SplitEmptyRecord:     false
+  SplitEmptyNamespace:  false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: false
+DerivePointerAlignment: false
+PointerAlignment: Left
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^[<"](gtest|gmock)'
+    Priority:        7
+  - Regex:           '^"config.h"'
+    Priority:        -1
+  - Regex:           '^".*\.h"'
+    Priority:        1
+  - Regex:           '^".*\.hpp"'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        3
+  - Regex:           '^<.*\.hpp>'
+    Priority:        4
+  - Regex:           '^<.*'
+    Priority:        5
+  - Regex:           '.*'
+    Priority:        6
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+TabWidth:        4
+UseCRLF: false
+UseTab:          Never
+...
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,3 @@
+subdir('tacf')
+incdir += include_directories('tacf')
+sources += files('pam_ibmacf.cpp')

--- a/src/pam_ibmacf.cpp
+++ b/src/pam_ibmacf.cpp
@@ -1,146 +1,20 @@
-#include "CeLogin.h"
-#include "CeLoginAsnV1.h"
-#include "CeLoginJson.h"
-#include "CeLoginUtil.h"
-#include "openssl/asn1.h"
-#include "openssl/asn1t.h"
-#include "openssl/err.h"
-#include "openssl/rsa.h"
-#include "openssl/x509.h"
-#include <map>
-#include <getopt.h>
 #include <security/pam_ext.h>
 #include <security/pam_modules.h>
-#include <security/pam_modutil.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <syslog.h>
-#include <unistd.h>
 
-#include <chrono>
-#include <ctime>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <variant>
-#include <vector>
+#include <tacf.hpp>
 
-#define SOURCE_FILE_VERSION 1
-#define UNSET_SERIAL_NUM_KEYWORD "UNSET"
-#define BLANK_SERIAL_NUMBER "       "
+#include <filesystem>
 
-//RUN_UNIT_TESTS should only be enabled when running
-//meson unit tests, otherwise this shoudn't be enabled
+// RUN_UNIT_TESTS should only be enabled when running
+// meson unit tests, otherwise this shoudn't be enabled
 #ifdef RUN_UNIT_TESTS
 #include "testconf.h"
 // print logs to stdout under test
 #define pam_syslog(X, Y, ...) printf(__VA_ARGS__)
-#else
-#include <sdbusplus/bus.hpp>
-#define ACF_FILE_PATH "/etc/acf/service.acf"
-#define PROD_PUB_KEY_FILE_PATH "/srv/ibm-acf/ibmacf-prod.key"
-#define PROD_BACKUP_PUB_KEY_FILE_PATH "/srv/ibm-acf/ibmacf-prod-backup.key"
-#define PROD_BACKUP2_PUB_KEY_FILE_PATH "/srv/ibm-acf/ibmacf-prod-backup2.key"
-#define DEV_PUB_KEY_FILE_PATH "/srv/ibm-acf/ibmacf-dev.key"
 #endif
 
-// DBUS definitions for getting host's serial number property
-#define DBUS_INVENTORY_SYSTEM_OBJECT "/xyz/openbmc_project/inventory/system"
-#define DBUS_INVENTORY_ASSET_INTERFACE                                         \
-    "xyz.openbmc_project.Inventory.Decorator.Asset"
-#define DBUS_SERIAL_NUM_PROP "SerialNumber"
-
 const char* default_user = "service";
-
-using namespace std;
-using namespace CeLogin;
-
-// mapping of failure codes to messages
-std::map<int, std::string> mapping = {
-    {0x00, "Success"},
-    {0x01, "Failure"},
-    {0x02, "UnsupportedVersion"},
-    {0x03, "SignatureNotValid"},
-    {0x04, "PasswordNotValid"},
-    {0x05, "AcfExpired"},
-    {0x06, "SerialNumberMismatch"},
-    {0x07, "JsonDataAllocationFailure"},
-
-    {0x13, "CreateHsf_PasswordHashFailure"},
-    {0x14, "CreateHsf_JsonHashFailure"},
-
-    {0x20, "DecodeHsf_AsnDecodeFailure"},
-    {0x21, "DecodeHsf_OidMismatchFailure"},
-    {0x22, "DecodeHsf_CreateJsonDigestFailure"},
-    {0x23, "DecodeHsf_PublicKeyAllocFailure"},
-    {0x24, "DecodeHsf_PublicKeyImportFailure"},
-    {0x25, "DecodeHsf_JsonParseFailure"},
-    {0x26, "DecodeHsf_VersionMismatch"},
-    {0x27, "DecodeHsf_ReadSerialNumberFailure"},
-    {0x28, "DecodeHsf_ReadFrameworkEcFailure"},
-    {0x29, "DecodeHsf_ReadMachineArrayFailure"},
-    {0x2A, "DecodeHsf_MachineArrayInvalidLength"},
-    {0x2B, "DecodeHsf_ReadHashedAuthCodeFailure"},
-    {0x2C, "DecodeHsf_ReadExpirationFailure"},
-    {0x2D, "DecodeHsf_ReadRequestIdFailure"},
-
-    {0x30, "VerifyAcf_AsnDecodeFailure"},
-    {0x31, "VerifyAcf_OidMismatchFailure"},
-    {0x32, "VerifyAcf_CreateJsonDigestFailure"},
-    {0x33, "VerifyAcf_PublicKeyAllocFailure"},
-    {0x34, "VerifyAcf_PublicKeyImportFailure"},
-    {0x35, "VerifyAcf_InvalidParm"},
-    {0x36, "VerifyAcf_Asn1CopyFailure"},
-    {0x37, "VerifyAcf_Nid2OidFailed"},
-    {0x38, "VerifyAcf_ProcessingTypeMismatch"},
-
-    {0x40, "DetermineAuth_PasswordHashFailure"},
-    {0x41, "DetermineAuth_Asn1TimeAllocFailure"},
-    {0x42, "DetermineAuth_Asn1TimeFromUnixFailure"},
-    {0x43, "DetermineAuth_AsnAllocFailure"},
-    {0x44, "DetermineAuth_Asn1TimeCompareFailure"},
-
-    {0x50, "Util_ValueFromJsonTagFailure"},
-
-    {0x60, "HexToBin_HexPairOverflow"},
-    {0x61, "HexToBin_InvalidHexString"},
-
-    {0x70, "DateFromString_StrtoulFailure"},
-    {0x71, "DateFromString_InvalidFormat"},
-    {0x72, "DateFromString_InvalidParm"},
-
-    {0x80, "GetAsn1Time_SetStringFailure"},
-    {0x81, "GetAsn1Time_FormatStringFailure"},
-    {0x82, "GetAsn1Time_InvalidParm"},
-
-    {0x90, "CreatePasswordHash_InvalidInputBuffer"},
-    {0x91, "CreatePasswordHash_InvalidInputBufferLength"},
-    {0x92, "CreatePasswordHash_InvalidOutputBuffer"},
-    {0x93, "CreatePasswordHash_InvalidOutputBufferLength"},
-    {0x94, "CreatePasswordHash_OsslCallFailed"},
-
-    {0xA0, "CreateDigest_InvalidInputBuffer"},
-    {0xA1, "CreateDigest_InvalidInputBufferLength"},
-    {0xA2, "CreateDigest_InvalidOutputBuffer"},
-    {0xA3, "CreateDigest_InvalidOutputBufferLength"},
-    {0xA4, "CreateDigest_OsslCallFailed"},
-
-    {0xB0, "GetUnsignedIntFromString_InvalidBuffer"},
-    {0xB1, "GetUnsignedIntFromString_ZeroLengthBuffer"},
-    {0xB2, "GetUnsignedIntFromString_IntegerOverflow"},
-    {0xB3, "GetUnsignedIntFromString_InvalidString"},
-
-    {0xC0, "GetAuthFromFrameworkEc_InvalidParm"},
-};
-enum verifyACFErrors
-{
-    verifyACF_NotInvoked = -1,
-    verifyACF_FailedReadingACF = -2,
-    verifyACF_FailedReadingKey = -3,
-};
-
 
 // Determine the user name of the auth attempt.
 // Returns:
@@ -149,8 +23,8 @@ enum verifyACFErrors
 //    PAM_IGNORE otherwise.
 int ignore_other_accounts(pam_handle_t* pamh, const char* user_parm)
 {
-    const char* login_user = NULL;
-    int retval = pam_get_user(pamh, &login_user, NULL);
+    const char* login_user = nullptr;
+    int retval             = pam_get_user(pamh, &login_user, nullptr);
     if (retval != PAM_SUCCESS)
     {
         pam_syslog(pamh, LOG_NOTICE, "Unable to get user name: %s\n",
@@ -165,99 +39,53 @@ int ignore_other_accounts(pam_handle_t* pamh, const char* user_parm)
 }
 
 bool readBinaryFile(const std::string fileNameParm,
-                    std::vector<uint8_t>& bufferParm, pam_handle_t* pamh)
+                    std::vector<uint8_t>& bufferParm)
 {
     std::ifstream sInputFile;
-    if (!fileNameParm.empty())
+    if (fileNameParm.empty())
     {
-        sInputFile.open(fileNameParm.c_str(), std::ios::in | std::ios::binary);
-        if (sInputFile.is_open())
-        {
-            // Get the size of the file
-            sInputFile.seekg(0, std::ios::end);
-            std::streampos size = sInputFile.tellg();
-            sInputFile.seekg(0, std::ios::beg);
-
-            bufferParm.reserve(size);
-            bufferParm.assign(size, 0);
-
-            sInputFile.read((char*)bufferParm.data(), size);
-            sInputFile.close();
-
-            return true;
-        }
-        else
-        {
-            pam_syslog(pamh, LOG_WARNING, "Failed to open file %s\n",
-                       fileNameParm.c_str());
-        }
-    }
-    else
-    {
-        pam_syslog(pamh, LOG_WARNING, "filename empty");
+        return false;
     }
 
-    return false;
+    // Open the file.
+    sInputFile.open(fileNameParm.c_str(), std::ios::binary);
+    sInputFile.unsetf(std::ios::skipws);
+    if (!sInputFile)
+    {
+        return false;
+    }
+
+    // Get the size of the file.
+    std::error_code ec;
+    std::filesystem::path path = fileNameParm;
+    std::uintmax_t size        = std::filesystem::file_size(path, ec);
+    if (ec)
+    {
+        return false;
+    }
+
+    // Read the file.
+    bufferParm.reserve(size);
+    bufferParm.assign(size, 0);
+    sInputFile.read((char*)bufferParm.data(), size);
+    sInputFile.close();
+
+    return true;
 }
 
-// Return value: one of verifyACFErrors or CeLogin::CeLoginRc.mReason
-int verifyACF(string acfPubKeypath, const char* passwordParm, string mSerialNumber,
-              pam_handle_t* pamh)
-{
-    string acfFileName = (ACF_FILE_PATH);
-    vector<uint8_t> sAcf;
-    time_t sTime = time(NULL);
-    const uint64_t passwordLengthParm = strlen(passwordParm);
-    const uint64_t timeSinceUnixEpocInSecondsParm = sTime;
-    vector<uint8_t> sPublicKey;
-    const char* serialNumberParm = mSerialNumber.data();
-    const uint64_t serialNumberLengthParm = mSerialNumber.size();
-    CeLogin::ServiceAuthority sAuth = CeLogin::ServiceAuth_None;
-
-    uint64_t sExpiration = 0;
-    if (readBinaryFile(acfFileName, sAcf, pamh))
-    {
-        if (readBinaryFile(acfPubKeypath, sPublicKey, pamh))
-        {
-            const uint8_t* publicKeyParm = (const uint8_t*)sPublicKey.data();
-            const uint64_t publicKeyLengthParm = sPublicKey.size();
-
-            const uint8_t* accessControlFileParm = sAcf.data();
-            const uint64_t accessControlFileLengthParm = sAcf.size();
-
-            CeLogin::CeLoginRc sRc = CeLogin::getServiceAuthorityV1(
-                accessControlFileParm, accessControlFileLengthParm,
-                passwordParm, passwordLengthParm,
-                timeSinceUnixEpocInSecondsParm, publicKeyParm,
-                publicKeyLengthParm, serialNumberParm, serialNumberLengthParm,
-                sAuth, sExpiration);
-            return sRc.mReason;
-        }
-        else
-        {
-            // A log entry was already sent for this
-            return verifyACF_FailedReadingKey;
-        }
-    }
-    else
-    {
-        // A log entry was already sent for this
-        return verifyACF_FailedReadingACF;
-    }
-    return PAM_SUCCESS;
-}
 #ifdef RUN_UNIT_TESTS
 int fieldModeEnabled = 1;
 string mSerialNumber = "UNSET";
-//manually set variables (fieldModeEnabled and mSerialNumber)
-//for googletest for as dbus objects
-//aren't available on non OpenBMC targets
+// manually set variables (fieldModeEnabled and mSerialNumber)
+// for googletest for as dbus objects
+// aren't available on non OpenBMC targets
 void setFieldModeProperty(int fieldModeEnabledParam)
 {
     fieldModeEnabled = fieldModeEnabledParam;
 }
 
-void setSerialNumberProperty(const string& obj){
+void setSerialNumberProperty(const string& obj)
+{
     mSerialNumber = obj;
 }
 #else
@@ -298,48 +126,9 @@ int readFieldMode(pam_handle_t* pamh)
     }
     // Something unexpected happened.  Either fw_printenv exited abnormally,
     // or gave unexpected results, or something else unexpected happened.
-    pam_syslog(pamh, LOG_ERR, "pclose failed stat=0x%X, message=%s\n",
-               stat, result.str().c_str());
+    pam_syslog(pamh, LOG_ERR, "pclose failed stat=0x%X, message=%s\n", stat,
+               result.str().c_str());
     return -1; // This should never happen
-}
-
-string readMachineSerialNumberProperty(const string& obj, const string& inf,
-                                       const string& prop, pam_handle_t* pamh)
-{
-    std::string propSerialNum = "";
-    std::string object = obj;
-    auto bus = sdbusplus::bus::new_default();
-    auto properties = bus.new_method_call(
-        "xyz.openbmc_project.Inventory.Manager", object.c_str(),
-        "org.freedesktop.DBus.Properties", "Get");
-    properties.append(inf);
-    properties.append(prop);
-    try
-    {
-        auto result = bus.call(properties);
-        if (!result.is_method_error())
-        {
-            std::variant<string> val;
-            result.read(val);
-            if (auto pVal = std::get_if<string>(&val))
-            {
-                propSerialNum.assign((pVal->data()), pVal->size());
-            }
-            else
-            {
-                pam_syslog(pamh, LOG_ERR,
-                           "could not get the host's serial number\n");
-            }
-        }
-    }
-    catch (const std::exception& exc)
-    {
-        pam_syslog(pamh, LOG_ERR,
-                   "dbus call for getting serial number failed: %s\n",
-                   exc.what());
-        propSerialNum = "";
-    }
-    return propSerialNum;
 }
 #endif
 
@@ -350,10 +139,12 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc,
     pam_fail_delay(pamh, 2'000'000);
 #endif // HAVE_PAM_FAIL_DELAY
 
-    const char* username = NULL;
+    const char* username = nullptr;
+
     // Only handle the service user.
     int retval = -1;
-    retval = pam_get_user(pamh, &username, NULL);
+    retval     = pam_get_user(pamh, &username, nullptr);
+
     if (retval != PAM_SUCCESS)
     {
         return retval;
@@ -365,7 +156,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc,
 
     // Get the user's password
     const char* password;
-    retval = pam_get_authtok(pamh, PAM_AUTHTOK, &password, NULL);
+    retval = pam_get_authtok(pamh, PAM_AUTHTOK, &password, nullptr);
 
     if (retval != PAM_SUCCESS)
     {
@@ -373,96 +164,33 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc,
         return PAM_AUTH_ERR;
     }
 
-    string acfDevPubKeypath = (DEV_PUB_KEY_FILE_PATH);
-    string acfProdPubKeypath = (PROD_PUB_KEY_FILE_PATH);
-    string acfProdBackupPubKeypath = (PROD_BACKUP_PUB_KEY_FILE_PATH);
-    string acfProdBackup2PubKeypath = (PROD_BACKUP2_PUB_KEY_FILE_PATH);
+    // Specify logging and get field mode overrides.
+    Tacf tacf{
+        [](void* pamh, std::string msg) {
+            pam_syslog((pam_handle_t*)pamh, LOG_WARNING, "%s", msg.c_str());
+        },
+        [](void* pamh) -> int { return readFieldMode((pam_handle_t*)pamh); },
+        pamh};
 
-    // Get host's serial number
-#ifndef RUN_UNIT_TESTS
-    string mSerialNumber = readMachineSerialNumberProperty(
-        DBUS_INVENTORY_SYSTEM_OBJECT, DBUS_INVENTORY_ASSET_INTERFACE,
-        DBUS_SERIAL_NUM_PROP, pamh);
-#endif
-    // If serial number is empty on machine set as UNSET for check with acf
-    if (mSerialNumber.empty() || (mSerialNumber == BLANK_SERIAL_NUMBER))
-    {
-        mSerialNumber = UNSET_SERIAL_NUM_KEYWORD;
-    }
-
-    // Check the ACF with the production key.  There are three outcomes:
-    //  1. Successful authentication.  Stop trying.
-    //  2. Failure because cannot verify signature.  Try next signature.
-    //  3. Failure because something else is wrong.  Stop trying.
-    int sRc = verifyACF(acfProdPubKeypath, password, mSerialNumber, pamh);
-    int sRc1 = sRc;
-    int sRc2 = verifyACF_NotInvoked;
-    int sRc3 = verifyACF_NotInvoked;
-    int sRc4 = verifyACF_NotInvoked;
-    int fieldMode = -1;
-    if ((sRc == CeLoginRc::SignatureNotValid) || (sRc == verifyACF_FailedReadingKey))
-    {
-        // Check the ACF with the backup production key.
-        sRc = verifyACF(acfProdBackupPubKeypath, password, mSerialNumber, pamh);
-        sRc2 = sRc;
-
-        if ((sRc == CeLoginRc::SignatureNotValid) || (sRc == verifyACF_FailedReadingKey))
-        {
-            // Check the ACF with the backup2 production key.
-            sRc = verifyACF(acfProdBackup2PubKeypath, password, mSerialNumber, pamh);
-            sRc3 = sRc;
-
-            // If field mode is disabled, check the ACF with the development key.
-            if ((sRc == CeLoginRc::SignatureNotValid) || (sRc == verifyACF_FailedReadingKey))
-            {
-                // Read the field mode value.
-#ifndef RUN_UNIT_TESTS
-                int fieldModeEnabled = readFieldMode(pamh);
-#endif
-                fieldMode = fieldModeEnabled;
-                if (fieldModeEnabled == -1)
-                {
-                    pam_syslog(pamh, LOG_ERR,
-                               "Could not read fieldmode value\n");
-                    // Continue securely: as if field mode is enabled
-                    fieldModeEnabled = 1;
-                }
-                if (fieldModeEnabled == 0)
-                {
-                    sRc = verifyACF(acfDevPubKeypath, password, mSerialNumber, pamh);
-                    sRc4 = sRc;
-                }
-            }
-        }
-    }
-
-    if (sRc == CeLoginRc::Success)
+    // And authenticate user with password.
+    int rc = tacf.authenticate(password);
+    if (Tacf::tacfSuccess == rc)
     {
         return PAM_SUCCESS;
     }
+    else
+    {
+        // Log the error
+        std::string errMsg = "Auth Error";
+        if (Tacf::tacfSystemError == rc)
+        {
+            errMsg = "System Error";
+        }
 
-    // Log the error
-    const char* errMsg = "";
-    auto errIter = mapping.find(sRc);
-    if (errIter != mapping.end())
-    {
-        errMsg = errIter->second.c_str();
+        pam_syslog(pamh, LOG_WARNING, "ACF service auth failed 0x%X: %s", rc,
+                   errMsg.c_str());
     }
-    if (sRc == verifyACF_FailedReadingACF)
-    {
-        errMsg = "FailedReadingACF";
-    }
-    pam_syslog(pamh, LOG_WARNING, "ACF service auth failed 0x%X: %s"
-               " (serial=%s, sRc1=0x%X, sRc2=0x%0x, sRc3=0x%X, sRc4=0x%X)",
-               sRc, errMsg, mSerialNumber.c_str(), sRc1, sRc2, sRc3, sRc4);
-           
-    if (sRc == verifyACF_FailedReadingACF || sRc == CeLoginRc::SignatureNotValid ||
-        sRc == CeLoginRc::PasswordNotValid || sRc == CeLoginRc::AcfExpired ||
-        sRc == CeLoginRc::SerialNumberMismatch)
-    {
-        return PAM_AUTH_ERR;
-    }
-    return PAM_SYSTEM_ERR;
+    return Tacf::tacfAuthError == rc ? PAM_AUTH_ERR : PAM_SYSTEM_ERR;
 }
 
 PAM_EXTERN int pam_sm_setcred(pam_handle_t* pamh, int flags, int argc,
@@ -476,7 +204,7 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t* pamh, int flags, int argc,
 {
     // Only handle the service user.
     const char* user_parm = default_user;
-    int retval = ignore_other_accounts(pamh, user_parm);
+    int retval            = ignore_other_accounts(pamh, user_parm);
     if (retval == PAM_IGNORE)
     {
         retval = PAM_PERM_DENIED;
@@ -501,8 +229,9 @@ PAM_EXTERN int pam_sm_chauthtok(pam_handle_t* pamh, int flags, int argc,
 {
     // Only handle the service user.  Reject all password changes.
     const char* user_parm = default_user;
-    int retval = ignore_other_accounts(pamh, user_parm);
-    switch(retval) {
+    int retval            = ignore_other_accounts(pamh, user_parm);
+    switch (retval)
+    {
         case PAM_SUCCESS:
             retval = PAM_AUTHTOK_ERR;
             break;

--- a/src/tacf/.clang-format
+++ b/src/tacf/.clang-format
@@ -1,0 +1,117 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction:   false
+  SplitEmptyRecord:     false
+  SplitEmptyNamespace:  false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: false
+DerivePointerAlignment: false
+PointerAlignment: Left
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^[<"](gtest|gmock)'
+    Priority:        7
+  - Regex:           '^"config.h"'
+    Priority:        -1
+  - Regex:           '^".*\.h"'
+    Priority:        1
+  - Regex:           '^".*\.hpp"'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        3
+  - Regex:           '^<.*\.hpp>'
+    Priority:        4
+  - Regex:           '^<.*'
+    Priority:        5
+  - Regex:           '.*'
+    Priority:        6
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+TabWidth:        4
+UseCRLF: false
+UseTab:          Never
+...
+

--- a/src/tacf/meson.build
+++ b/src/tacf/meson.build
@@ -1,0 +1,15 @@
+tacf_files = files('tacf.hpp',
+                   'tacfCelogin.hpp',
+                   'tacfDbus.hpp',
+                   'tacfSpw.hpp',
+                   'targetedAcf.hpp')
+
+tacf_dep = declare_dependency(sources : tacf_files, include_directories :  incdir)
+
+pkg_mod = import('pkgconfig').generate(libraries: tacf_dep,
+                                       name : 'tacf',
+                                       subdirs : 'tacf',
+                                       version : '1.0',
+                                       description : 'IBM Targeted ACF support')
+
+install_headers(tacf_files, subdir : 'tacf')

--- a/src/tacf/tacf.hpp
+++ b/src/tacf/tacf.hpp
@@ -1,0 +1,542 @@
+#pragma once
+
+#include "tacfCelogin.hpp"
+#include "tacfDbus.hpp"
+#include "tacfSpw.hpp"
+#include "targetedAcf.hpp"
+
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+constexpr unsigned int TargetedAcf::acfTypeInvalid =
+    CeLogin::AcfType::AcfType_Invalid;
+
+constexpr unsigned int TargetedAcf::acfTypeAdminReset =
+    CeLogin::AcfType::AcfType_AdminReset;
+
+constexpr unsigned int TargetedAcf::acfTypeService =
+    CeLogin::AcfType::AcfType_Service;
+
+const auto pubkeysProd = std::to_array<std::string>(
+    {"/srv/ibm-acf/ibmacf-prod.key", "/srv/ibm-acf/ibmacf-prod-backup.key",
+     "/srv/ibm-acf/ibmacf-prod-backup2.key"});
+
+const auto pubkeysDev =
+    std::to_array<std::string>({"/srv/ibm-acf/ibmacf-dev.key"});
+
+constexpr auto acfFilePath = "/etc/acf/service.acf";
+
+constexpr auto replayFilePath = "/etc/acf/acfv2.replay";
+
+constexpr auto serialNumberEmpty = "       ";
+
+constexpr auto serialNumberUnset = "UNSET";
+
+// Function pointers for optional alternate functions.
+typedef void (*logging_function)(std::string);
+typedef void (*logging_function_pam)(void*, std::string);
+typedef int (*field_mode_function_pam)(void*);
+
+/**
+ * Tacf class for implementing targeted ACF feature.
+ *
+ * Constructor example for logging with phosphor::logging
+ *
+ *   Tacf tacf{[](std::string msg) {
+ *        log<phosphor::logging::level::INFO>(msg.c_str());
+ *   }};
+ *
+ * Constructor example for logging with pam_syslog
+ *
+ *   Tacf tacf{[](void* pamh, std::string msg) {
+ *        pam_syslog((pam_handle_t*)pamh, LOG_WARNING, "%s",
+ *        msg.c_str());
+ *   }, pamh};
+ *
+ *
+ */
+class Tacf : TargetedAcf
+{
+  public:
+    Tacf(logging_function logger = nullptr) : logger(logger) {}
+
+    Tacf(logging_function_pam logger, void* handle) :
+        loggerPam(logger), pamHandle(handle)
+    {}
+
+    Tacf(logging_function_pam logger, field_mode_function_pam fieldmode,
+         void* handle) :
+        loggerPam(logger),
+        fieldModePam(fieldmode), pamHandle(handle)
+    {}
+
+    /**
+     * Authenticate against an ACF using a password.
+     * @brief Authenticate using password.
+     *
+     * @param password  A pointer to a password used for authentication.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int authenticate(const char* password)
+    {
+        if (!password)
+        {
+            return tacfAuthError;
+        }
+
+        std::vector<uint8_t> acf;
+        if (readFile(acfFilePath, acf))
+        {
+            return tacfSystemError;
+        }
+
+        std::string expires;
+        int rc = TargetedAcf::targetedAuth(
+            acf.data(), acf.size(), expires,
+            TargetedAcf::TargetedAcfAction::Authenticate, password);
+        log("acfv2-authenticate-%0x", rc);
+        return rc;
+    }
+
+    /**
+     * Install ACF and retrieve expiration data.
+     * @brief Install ACF.
+     *
+     * @param acf       A pointer to an ASN1 encoded binary ACF.
+     * @param acfSize   The size of the ASN1 encoded binary ACF.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int install(const uint8_t* acf, size_t acfSize, std::string& expires)
+    {
+        if (!acf || !acfSize)
+        {
+            return tacfAuthError;
+        }
+
+        // password (nullptr) not used for ACF install
+        int rc = TargetedAcf::targetedAuth(
+            acf, acfSize, expires, TargetedAcf::TargetedAcfAction::Install,
+            nullptr);
+        log("acfv2-install-%0x", rc);
+        return rc;
+    }
+
+    /**
+     * Verify ACF and retrieve expiration data.
+     * @brief Verify ACF.
+     *
+     * @param acf       A pointer to an ASN1 encoded binary ACF.
+     * @param acfSize   The size of the ASN1 encoded binary ACF.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int verify(const uint8_t* acf, size_t acfSize, std::string& expires)
+    {
+        if (!acf || !acfSize)
+        {
+            return tacfAuthError;
+        }
+
+        int rc = TargetedAcf::targetedAuth(
+            acf, acfSize, expires, TargetedAcf::TargetedAcfAction::Verify,
+            nullptr);
+        log("acfv2-verify-%0x", rc);
+        return rc;
+    }
+
+    static constexpr int tacfSuccess     = 0;
+    static constexpr int tacfFail        = 1;
+    static constexpr int tacfSystemError = 0x10001;
+    static constexpr int tacfAuthError   = 0x10002;
+
+  private:
+    /** @brief Optional logging support to register */
+    logging_function logger              = nullptr;
+    logging_function_pam loggerPam       = nullptr;
+    field_mode_function_pam fieldModePam = nullptr;
+    void* pamHandle                      = nullptr;
+
+    /**
+     * Process an ACF. Depending on the action requested and the type of
+     * ACF presented this operation will result in one or more of the
+     * following: validate ACF signature and structure, retrieve an
+     * associated user auth code, retrieve the ACF expiration date,
+     * retrieve an updated replay id.
+     * @brief Process an ACF.
+     *
+     * @param acf       A pointer to an ASN1 encoded binary ACF.
+     * @param acfSize   The size of the ASN1 encoded binary ACF.
+     * @param auth      The user auth value to populate.
+     * @param type      The ACF type value to populate.
+     * @param expires   The ACF expiration date to populate.
+     * @param replayId  The current and updated replay id value.
+     * @param action    The type of action to perform with the ACF.
+     * @param password  A pointer to a password for authentication.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int getAuth(const uint8_t* acf, size_t acfSize, std::string& auth,
+                        unsigned int& type, std::string& expires,
+                        uint64_t& replayId,
+                        TargetedAcf::TargetedAcfAction action,
+                        const char* password) final override
+    {
+        // Get serial number.
+        std::string serial;
+        if (retrieveSerial(serial))
+        {
+            return tacfFail;
+        }
+
+        // Get list of public keys to check signature against.
+        std::vector<std::string> keyring;
+        copy(begin(pubkeysProd), end(pubkeysProd), back_inserter(keyring));
+
+        // If field mode disabled then also use development public key(s).
+        bool fieldMode = true;
+        if (!retrieveFieldMode(fieldMode) && !fieldMode)
+        {
+            copy(begin(pubkeysDev), end(pubkeysDev), back_inserter(keyring));
+        }
+
+        // Process ACF using auth provider with each key.
+        TacfCelogin authProvider;
+        int authRc = CeLogin::CeLoginRc::Failure;
+
+        for (auto pathname : keyring)
+        {
+            // Skip key if file does not exist or is empty.
+            std::vector<uint8_t> pubkey;
+            if (readFile(pathname, pubkey) || pubkey.empty())
+            {
+                continue;
+            }
+
+            int authRc;
+            uint64_t expireTime = 0;
+
+            // If action is verify.
+            if (TargetedAcf::TargetedAcfAction::Verify == action)
+            {
+                // Verify ACF.
+                authRc = authProvider.verify(acf, acfSize, pubkey.data(),
+                                             pubkey.size(), serial, expireTime);
+            }
+            // Or if action is install.
+            else if (TargetedAcf::TargetedAcfAction::Install == action)
+            {
+                CeLogin::AcfType ceLoginAcfType =
+                    CeLogin::AcfType::AcfType_Invalid;
+
+                // Install ACF.
+                authRc = authProvider.install(
+                    acf, acfSize, pubkey.data(), pubkey.size(), serial, auth,
+                    ceLoginAcfType, expireTime, replayId);
+
+                // Convert from celogin ACF type to targeted ACF type.
+                type = translateAcfType(ceLoginAcfType);
+            }
+            else
+            {
+                // Otherwise authenticate with password.
+                authRc = authProvider.authenticate(acf, acfSize, pubkey.data(),
+                                                   pubkey.size(), password,
+                                                   serial, replayId);
+            }
+
+            // If action successful.
+            if (CeLogin::CeLoginRc::Success == authRc)
+            {
+                // Get expiration date
+                expires = getDate(expireTime);
+
+                // And return success.
+                return tacfSuccess;
+            }
+        }
+        // Or return error code.
+        return authRc;
+    }
+
+    /**
+     * Retrieve a previously stored replay id.
+     * @brief Retrieve replay id.
+     *
+     * @param id    A replay id value to populate.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int retrieveReplayId(uint64_t& id) final override
+    {
+        if (TacfDbus().readReplayId(id))
+        {
+            log("acfv2 retrieve replay error");
+            return tacfSystemError;
+        }
+
+        return tacfSuccess;
+    }
+
+    /**
+     * Store a new replay id overwriting existing replay id.
+     * @brief Store replay id.
+     *
+     * @param id        A replay id value to store.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int storeReplayId(uint64_t id) final override
+    {
+        if (TacfDbus().writeReplayId(id))
+        {
+            log("acfv2 store replay error");
+            return tacfSystemError;
+        }
+
+        return tacfSuccess;
+    }
+
+    /**
+     * Reset the admin user account.
+     * @brief Reset admin.
+     *
+     * @param spw  The value to use for admin user shadow password.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int resetAdmin(const std::string& spw) final override
+    {
+        if (TacfSpw().resetAdmin(spw))
+        {
+            log("acfv2 reset error");
+            return tacfSystemError;
+        }
+
+        return tacfSuccess;
+    }
+
+    /**
+     * Remove the previously installed ACF.
+     * @brief Remove ACF.
+     */
+    virtual void removeAcf() override
+    {
+        std::remove(acfFilePath);
+    }
+
+    /**
+     * Install the new ACF.
+     * @brief Install ACF.
+     *
+     * @param acf       A pointer to an ASN1 encoded binary ACF.
+     * @param size      The size of the ASN1 encoded binary ACF.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int installAcf(const uint8_t* acf, size_t size)
+    {
+        if (!acf || !size)
+        {
+            log("acfv2 install error");
+            return tacfFail;
+        }
+
+        return writeFile(acf, size, acfFilePath);
+    }
+
+    /**
+     * Retrieve the serial number of the system.
+     * @brief retrieve serial number.
+     *
+     * @param serial    serial number value to populate.
+     *
+     * @return a non-zero error value or zero on success.
+     */
+    virtual int retrieveSerial(std::string& serial) const
+    {
+        if (TacfDbus().retrieveSerialNumber(serial))
+        {
+            log("acfv2 retrieve serial error");
+            return tacfSystemError;
+        }
+        else
+        {
+            // Convert empty serial number to ACF form.
+            if (serial.empty() || serialNumberEmpty == serial)
+            {
+                serial = serialNumberUnset;
+            }
+        }
+
+        return tacfSuccess;
+    }
+
+    /**
+     * Determined if system is operating in field mode.
+     * @brief Retrieve field mode state.
+     *
+     * @param fieldMode Field mode enabled state to populate.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int retrieveFieldMode(bool& fieldMode) const
+    {
+        // If alternate get field mode registered.
+        if (nullptr != fieldModePam)
+        {
+            // Use alternate method.
+            int mode = fieldModePam(pamHandle);
+            switch (mode)
+            {
+                case 0:
+                    fieldMode = false;
+                    break;
+                case 1:
+                    fieldMode = true;
+                    break;
+                default:
+                    fieldMode = true;
+                    log("acfv2 pam retrieve field error");
+                    return tacfSystemError;
+            }
+        }
+        // Otherwise use default method.
+        else if (TacfDbus().retrieveFieldMode(fieldMode))
+        {
+            log("acfv2 retrieve field error");
+            return tacfSystemError;
+        }
+
+        return tacfSuccess;
+    }
+
+    /**
+     * Read a file in into a vector of bytes.
+     * @brief Read a binary file.
+     *
+     * @param pathname  The path and name of the file to read.
+     * @param buffer    The vector to read the file into.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int readFile(const std::string& pathname,
+                 std::vector<uint8_t>& buffer) const
+    {
+        std::ifstream file(pathname, std::ios::binary);
+        file.unsetf(std::ios::skipws);
+
+        if (!file)
+        {
+            log("acfv2 read file error");
+            return tacfSystemError;
+        }
+        try
+        {
+            std::copy(std::istream_iterator<uint8_t>(file),
+                      std::istream_iterator<uint8_t>(),
+                      std::back_inserter(buffer));
+        }
+        catch (std::exception& e)
+        {
+            log("acfv2 read file exception");
+            return tacfSystemError;
+        }
+
+        return tacfSuccess;
+    }
+
+    /**
+     * Write a vector of bytes to a file.
+     * @brief Write a binary file.
+     *
+     * @param buffer    A pointer to an ASN1 encoded binary ACF.
+     * @param size      The size of the ASN1 encoded binary ACF.
+     * @param pathname  The path and name of the file to write.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int writeFile(const uint8_t* buffer, const size_t size,
+                  const std::string& pathname) const
+    {
+        std::ofstream file(pathname, std::ios::trunc | std::ios::binary);
+
+        if (!file)
+        {
+            log("acfv2 write file error");
+            return tacfSystemError;
+        }
+
+        file.write((const char*)buffer, size);
+
+        return tacfSuccess;
+    }
+
+    /** @brief Helper function for logging */
+    void inf(const char* format, va_list args) const
+    {
+        char msg[255];
+        vsnprintf(msg, 255, format, args);
+        std::string msgString(msg);
+        if (logger)
+        {
+            logger(msgString);
+        }
+        else if (loggerPam && pamHandle)
+        {
+            loggerPam(pamHandle, msgString);
+        }
+    }
+
+    /** @brief Helper function for formatted logging */
+    void log(const char* format, ...) const
+    {
+        if (!logger && !loggerPam)
+        {
+            return;
+        }
+        va_list args;
+        va_start(args, format);
+        inf(format, args);
+        va_end(args);
+    }
+
+    /** @brief A helper function to convert timestamp to date */
+    std::string getDate(const uint64_t timestamp)
+    {
+        // Get expiration date
+        struct tm* t = gmtime(reinterpret_cast<const time_t*>(&timestamp));
+        std::string buffer(100, ' ');
+        size_t written = std::strftime(buffer.data(), buffer.size(), "%F", t);
+        buffer.resize(written);
+
+        return buffer;
+    }
+
+    /** @brief A helper function to convert between acf types */
+    unsigned int translateAcfType(CeLogin::AcfType type)
+    {
+        unsigned int tacfType;
+
+        switch (type)
+        {
+            case CeLogin::AcfType::AcfType_AdminReset:
+                tacfType = TargetedAcf::acfTypeAdminReset;
+                break;
+
+            case CeLogin::AcfType::AcfType_Service:
+                tacfType = TargetedAcf::acfTypeService;
+                break;
+
+            default:
+                tacfType = TargetedAcf::acfTypeInvalid;
+        }
+
+        return tacfType;
+    }
+};

--- a/src/tacf/tacfCelogin.hpp
+++ b/src/tacf/tacfCelogin.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <CeLogin.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+/**
+ * TacfCelogin class for access control file (ACF) processing.
+ * @brief ACF processing, celogin specific.
+ */
+class TacfCelogin
+{
+  public:
+    /**
+     * Authenticate against ACF using a password.
+     * @brief ACF authentication.
+     *
+     * @param acf           A pointer to an ASN1 encoded binary ACF.
+     * @param acfSize       The size of the ASN1 encoded binary ACF.
+     * @param pubkey        A Pointer to a public key for validating the ACF.
+     * @param pubkeySize    The size of the pulic key being provided.
+     * @param password      Pointer to a password for authentication.
+     * @param serial        Serial number of machine associated with the ACF.
+     * @param replayId      Current and updated replay id value.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int authenticate(const uint8_t* acf, const uint64_t acfSize,
+                     const uint8_t* pubkey, const uint64_t pubkeySize,
+                     const char* password, const std::string& serial,
+                     uint64_t& replayId)
+    {
+        uint64_t timestamp = getTimestamp();
+
+        CeLogin::AcfUserFields acfUserFields;
+
+        // Authenticate with password.
+        CeLogin::CeLoginRc authRc =
+            CeLogin::checkAuthorizationAndGetAcfUserFieldsV2(
+                acf, acfSize, password, strlen(password), timestamp, pubkey,
+                pubkeySize, serial.data(), serial.size(), replayId,
+                acfUserFields);
+
+        // Return celogin specific error code.
+        if (CeLogin::CeLoginRc::Success != authRc)
+        {
+            return authRc;
+        }
+
+        // Or success.
+        return 0;
+    }
+
+    /**
+     * Install ACF and retrieve a the ACF type, replay id, expiration time. In
+     * the case of ACF type admin-reset the ecrypted admin password associated
+     * with the ACF will also be returned.
+     * @brief ACF installation.
+     *
+     * @param acf           A pointer to an ASN1 encoded binary ACF.
+     * @param acfSize       The size of the ASN1 encoded binary ACF.
+     * @param pubkey        A Pointer to a public key for validating the ACF.
+     * @param pubkeySize    The size of the pulic key being provided.
+     * @param serial        Serial number of machine associated with the ACF.
+     * @param auth          A user auth value to populate.
+     * @param type          The ACF type value to populate.
+     * @param expires       The ACF expiration time to populate.
+     * @param replay        Current and updated replay id value.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int install(const uint8_t* acf, const uint64_t acfSize,
+                const uint8_t* pubkey, const uint64_t pubkeySize,
+                const std::string& serial, std::string& auth,
+                CeLogin::AcfType& type, uint64_t& expires, uint64_t& replayId)
+    {
+        uint64_t replayIdNew;
+        uint64_t timestamp = getTimestamp();
+
+        // Verify signature and get ACF type.
+        CeLogin::CeLoginRc authRc = CeLogin::verifyACFForBMCUploadV2(
+            acf, acfSize, timestamp, pubkey, pubkeySize, serial.data(),
+            serial.size(), replayId, replayIdNew, type, expires);
+
+        // Return celogin specific error code.
+        if (CeLogin::CeLoginRc::Success != authRc)
+        {
+            return authRc;
+        }
+
+        CeLogin::AcfUserFields acfUserFields;
+
+        // If ACF was reset-admin type then populate admin auth code.
+        if (CeLogin::AcfType::AcfType_AdminReset == type)
+        {
+            // Validate ACF and retrieve user field
+            authRc = CeLogin::checkAuthorizationAndGetAcfUserFieldsV2(
+                acf, acfSize, nullptr, 0, timestamp, pubkey, pubkeySize,
+                serial.data(), serial.size(), replayIdNew, acfUserFields);
+
+            // Return celogin specific error code.
+            if (CeLogin::CeLoginRc::Success != authRc)
+            {
+                return authRc;
+            }
+
+            // Get the encrypted admin password as a string.
+            auth = std::string(acfUserFields.mTypeSpecificFields
+                                   .mAdminResetFields.mAdminAuthCode,
+                               acfUserFields.mTypeSpecificFields
+                                       .mAdminResetFields.mAdminAuthCode +
+                                   acfUserFields.mTypeSpecificFields
+                                       .mAdminResetFields.mAdminAuthCodeLength);
+        }
+
+        // Update the replay id.
+        replayId = replayIdNew;
+
+        // And return success.
+        return 0;
+    }
+
+    /**
+     * Verify the ACF and the the expiration time.
+     * @brief ACF verification.
+     *
+     * @param acf           A pointer to an ASN1 encoded binary ACF.
+     * @param acfSize       The size of the ASN1 encoded binary ACF.
+     * @param pubkey        A Pointer to a public key for validating the ACF.
+     * @param pubkeySize    The size of the pulic key being provided.
+     * @param serial        Serial number of machine associated with the ACF.
+     * @param expires       The ACF expiration date to populate.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int verify(const uint8_t* acf, const uint64_t acfSize,
+               const uint8_t* pubkey, const uint64_t pubkeySize,
+               const std::string& serial, uint64_t& expires)
+    {
+        uint64_t timestamp           = getTimestamp();
+        CeLogin::AcfType ceLoginType = CeLogin::AcfType::AcfType_Invalid;
+        CeLogin::AcfVersion version  = CeLogin::CeLoginInvalidVersion;
+        bool hasReplay               = false;
+
+        // Verify the ACF and get ACF expiration time.
+        CeLogin::CeLoginRc authRc = CeLogin::extractACFMetadataV2(
+            acf, acfSize, timestamp, pubkey, pubkeySize, serial.data(),
+            serial.size(), ceLoginType, expires, version, hasReplay);
+
+        // Return celogin specific error code.
+        if (CeLogin::CeLoginRc::Success != authRc)
+        {
+            return authRc;
+        }
+
+        // Or success.
+        return 0;
+    }
+
+  private:
+    /** @brief A helper function to get a current timestamp */
+    uint64_t getTimestamp()
+    {
+        // Encode current system time as a unix timestamp.
+        return std::chrono::duration_cast<std::chrono::seconds>(
+                   (std::chrono::system_clock::now()).time_since_epoch())
+            .count();
+    }
+};

--- a/src/tacf/tacfDbus.hpp
+++ b/src/tacf/tacfDbus.hpp
@@ -1,0 +1,216 @@
+#pragma once
+
+#include <sdbusplus/bus.hpp>
+
+#include <cstdint>
+#include <variant>
+
+/**
+ * TacfBus class for interacting with dbus objects.
+ */
+class TacfDbus
+{
+  public:
+    /**
+     * @brief Types of properties expected to be read.
+     */
+    using PropertyVariant =
+        std::variant<std::string, bool, std::vector<uint8_t>>;
+
+    /**
+     * Retrieve the serial number using dbus get properties interface.
+     * @brief retrieve the serial number.
+     *
+     * @param serial    serial number value to populate.
+     *
+     * @return a non-zero error value or zero on success.
+     */
+    int retrieveSerialNumber(std::string& serial) const
+    {
+        PropertyVariant message;
+
+        if (dbusGetProperty("xyz.openbmc_project.Inventory.Manager",
+                            "/xyz/openbmc_project/inventory/system",
+                            "xyz.openbmc_project.Inventory.Decorator.Asset",
+                            "SerialNumber", message))
+        {
+            return 1;
+        }
+
+        // Serial number is a string type.
+        if (auto value = std::get_if<std::string>(&message))
+        {
+            serial = *value;
+        }
+        else
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Retrieve the field mode state using dbus get properties interface.
+     * @brief Retrieve field mode state.
+     *
+     * @param enabled    Field mode enabled state to populate.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int retrieveFieldMode(bool& enabled) const
+    {
+        enabled = false;
+
+        PropertyVariant message;
+
+        if (dbusGetProperty("xyz.openbmc_project.Software.BMC.Updater",
+                            "/xyz/openbmc_project/software",
+                            "xyz.openbmc_project.Control.FieldMode",
+                            "FieldModeEnabled", message))
+        {
+            return 1;
+        }
+
+        // Field mode is a boolean type.
+        if (auto value = std::get_if<bool>(&message))
+        {
+            enabled = *value;
+        }
+        else
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Read the ACF replay Id using dbus get properties interface.
+     * @brief Read the ACF replay Id.
+     *
+     * @param replay    The replay Id to populate.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int readReplayId(uint64_t& replay) const
+    {
+        PropertyVariant message;
+
+        if (dbusGetProperty(
+                "xyz.openbmc_project.Inventory.Manager",
+                "/xyz/openbmc_project/inventory/system/chassis/motherboard",
+                "com.ibm.ipzvpd.UTIL", "F0", message))
+        {
+            return 1;
+        }
+
+        // Replay id is a vector of bytes.
+        uint64_t replayInt = 0;
+        if (auto value = std::get_if<std::vector<uint8_t>>(&message))
+        {
+            // Convert from bytes to int.
+            for (auto it = value->rbegin(); it != value->rend(); ++it)
+            {
+                replayInt = ((replayInt << 8) | (uint64_t)*it);
+            }
+        }
+        else
+        {
+            return 1;
+        }
+        replay = replayInt;
+        return 0;
+    }
+
+    /**
+     * Write the ACF replay Id using dbus interface.
+     * @brief Write the ACF replay ID.
+     *
+     * @param replay    The replay Id to write.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int writeReplayId(uint64_t replay) const
+    {
+        // Craft the dbus method for writing the replay Id.
+        auto bus = sdbusplus::bus::new_system();
+        auto method =
+            bus.new_method_call("com.ibm.VPD.Manager", "/com/ibm/VPD/Manager",
+                                "com.ibm.VPD.Manager", "WriteKeyword");
+
+        // Convert to bytes.
+        std::vector<uint8_t> replayBytes;
+        for (size_t i = 0; i < sizeof(replay); ++i)
+        {
+            replayBytes.push_back((uint8_t)(replay >> (8 * i)));
+        }
+
+        // Append the dbus method parameters.
+        method.append(
+            static_cast<sdbusplus::message::object_path>(
+                "/xyz/openbmc_project/inventory/system/chassis/motherboard"),
+            "UTIL", "F0", replayBytes);
+
+        try
+        {
+            // Check if dbus method call returned an error.
+            auto response = bus.call(method);
+            if (response.is_method_error())
+            {
+                return 1;
+            }
+        }
+        catch (const std::exception& exc)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+  private:
+    /**
+     * Retrieve a property stored as a dbus property.
+     * @brief Retrieve a property.
+     *
+     * @param service   The service hosting the property object and interface.
+     * @param path      The path of the dbus object hosting the interface .
+     * @param interface The interface for reading the property.
+     * @param property  The property to get.
+     * @param message   The message returned by the dbus get property method.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int dbusGetProperty(std::string service, std::string path,
+                        std::string interface, std::string property,
+                        PropertyVariant& message) const
+    {
+        // Craft the dbus method for reading the specified property.
+        auto bus = sdbusplus::bus::new_default();
+        auto method =
+            bus.new_method_call(service.c_str(), path.c_str(),
+                                "org.freedesktop.DBus.Properties", "Get");
+        method.append(interface, property);
+
+        // Try to read the dbus property.
+        try
+        {
+            // Check if dbus method call returned an error.
+            auto response = bus.call(method);
+            if (response.is_method_error())
+            {
+                return 1;
+            }
+
+            // Retrieve the dbus method response message.
+            response.read(message);
+        }
+        catch (const std::exception& exc)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+};

--- a/src/tacf/tacfSpw.hpp
+++ b/src/tacf/tacfSpw.hpp
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <shadow.h>
+#include <unistd.h>
+
+#include <iostream>
+
+/**
+ * TacfSpw class for manipulating the linux shadow file
+ */
+class TacfSpw
+{
+    /*
+     * @brief Implementation specific value definitions.
+     */
+    static constexpr auto spwFilePath = "/etc/shadow";
+    static constexpr auto adminName   = "admin";
+
+  public:
+    /**
+     * Reset the admin user account.
+     * @brief Reset the admin.
+     *
+     * @param adminSpw  The value to use for admin user shadow password.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int resetAdmin(const std::string& adminSpw)
+    {
+        // Prepare for shadow password database access.
+        setspent();
+
+        // If admin user does not exist we can not reset.
+        if (nullptr == getspnam(adminName))
+        {
+            endspent();
+            return 1;
+        }
+
+        // Reset the admin user shadow password.
+        return spwSetSpw(adminName, adminSpw);
+    }
+
+  private:
+    FILE* spwFile = nullptr;
+
+    /**
+     * Update the admin user shadow password and expire the password.
+     * @brief Reset the admin user account password.
+     *
+     * @param adminSpw  The value to set as the admin user shadow password.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int spwSetSpw(const std::string& name, const std::string& spw)
+    {
+        // Need name, password and access to shadow password file.
+        if (name.empty() || spw.empty() || spwBegin())
+        {
+            return 1;
+        }
+
+        spwd* spwDbEntry;
+        spwd spwEntry;
+
+        // Read each shadow password entry.
+        while ((spwDbEntry = getspent()))
+        {
+            // If the admin user name is found, save the details and skip.
+            if (name == spwDbEntry->sp_namp)
+            {
+                spwEntry           = *spwDbEntry;
+                spwEntry.sp_namp   = (char*)name.c_str(); // not needed
+                spwEntry.sp_pwdp   = (char*)spw.c_str();
+                spwEntry.sp_lstchg = 0;
+                continue;
+            }
+            // Write shadow password entry to shadow password file.
+            putspent(spwDbEntry, spwFile);
+        }
+        // Write admin user entry, will discard if empty.
+        putspent(&spwEntry, spwFile);
+
+        // Finished with password database and file.
+        spwEnd();
+
+        return 0;
+    }
+
+    /**
+     * Update shadow password file size and close file.
+     * @brief Close shadow password file.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int spwClose()
+    {
+        int rc = 0;
+
+        // Verify we have shadow password file opened.
+        if (nullptr != spwFile)
+        {
+            // Files size may have changed so truncate.
+            long int fsize = ftell(spwFile);
+            if (ftruncate(fileno(spwFile), fsize) < 0)
+            {
+                rc = 1;
+            }
+
+            // Close the shadow password file.
+            fclose(spwFile);
+        }
+
+        spwFile = nullptr;
+
+        return rc;
+    }
+
+    /**
+     * Open the shadow password file for reading and writing.
+     * @brief Open shadow password file.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int spwOpen()
+    {
+        // Verify shadow password file not opened.
+        if (nullptr != spwFile)
+        {
+            return 1;
+        }
+
+        // Open the shadow password file.
+        spwFile = fopen(spwFilePath, "r+");
+
+        return nullptr == spwFile ? 1 : 0;
+    }
+
+    /**
+     * Initialize shadow password database and open shadow password file.
+     * @brief Begin shadow password file changes.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int spwBegin()
+    {
+        int unlocked, lcount = 4;
+
+        // Try to reserve access to shadow password file
+        do
+        {
+            unlocked = lckpwdf();
+            lcount--;
+        } while (unlocked && lcount);
+
+        // Not able to reserve.
+        if (unlocked)
+        {
+            return 1;
+        }
+
+        // Initialize shadow password database.
+        setspent();
+
+        // If can not open shadow password file.
+        if (spwOpen())
+        {
+            // Relese shadow password resources.
+            spwEnd();
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Release shadow password database and shadow password file.
+     * @brief End shadow password file changes.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    void spwEnd()
+    {
+        // Close shadow password file.
+        spwClose();
+
+        // Release shadow password database resources.
+        endspent();
+
+        // Release shadow password file.
+        ulckpwdf();
+    }
+};

--- a/src/tacf/targetedAcf.hpp
+++ b/src/tacf/targetedAcf.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+/**
+ * TargetedAcf class for targeted access control file (ACF) features.
+ */
+class TargetedAcf
+{
+  public:
+    enum class TargetedAcfAction
+    {
+        Invalid,
+        Install,
+        Authenticate,
+        Verify
+    };
+
+    /**
+     * TargetedAcf object default destructor.
+     * @brief destructor
+     */
+    virtual ~TargetedAcf() = default;
+
+  protected:
+    /**
+     * Submit an ACF for targeted processing.
+     * @brief Process ACF.
+     *
+     * @param acf       A pointer to an ASN1 encoded binary ACF.
+     * @param size      The size of the ASN1 encoded binary ACF.
+     * @param expires   The ACF expiration date to populate.
+     * @param action    The action to perform if the ACF validates.
+     * @param password  A pointer to a password for authentication.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    int targetedAuth(const uint8_t* acf, size_t size, std::string& expires,
+                     TargetedAcfAction action, const char* password)
+    {
+        // Get previous anti-replay id.
+        uint64_t replay;
+        int rc = retrieveReplayId(replay);
+
+        if (!rc)
+        {
+            // Remember current replay id in case install fails.
+            uint64_t originalReplay = replay;
+
+            unsigned int type = acfTypeInvalid;
+            std::string auth;
+
+            // Process the ACF.
+            rc = getAuth(acf, size, auth, type, expires, replay, action,
+                         password);
+
+            // If processing successful.
+            if (!rc)
+            {
+                // And action was install.
+                if (TargetedAcfAction::Install == action)
+                {
+                    // Store updated replay Id.
+                    if (replay != originalReplay)
+                    {
+                        rc = storeReplayId(replay);
+                    }
+
+                    // If replay id updated.
+                    if (!rc)
+                    {
+                        // And ACF type is admin-reset.
+                        if (acfTypeAdminReset == type)
+                        {
+                            // Reset admin account.
+                            rc = resetAdmin(auth);
+
+                            if (!rc)
+                            {
+                                // And remove old ACF.
+                                removeAcf();
+                            }
+                        }
+
+                        // Or if ACF type is service.
+                        else if (acfTypeService == type)
+                        {
+                            // Then install new ACF.
+                            rc = installAcf(acf, size);
+                        }
+
+                        // If install action was not successful.
+                        if (rc)
+                        {
+                            // Restore original replay Id.
+                            storeReplayId(originalReplay);
+                        }
+                    }
+                }
+            }
+        }
+        return rc;
+    }
+
+  protected:
+    /**
+     * @brief Implementation specific value definitions.
+     */
+    const static unsigned int acfTypeService;
+    const static unsigned int acfTypeAdminReset;
+    const static unsigned int acfTypeInvalid;
+
+  private:
+    /**
+     * Validate ACF and retrieve an associated user auth code, ACF type
+     * value and updated ACF replay id.
+     * @brief Retrieve user auth, ACF type and replay id.
+     *
+     * @param acf       A pointer to an ASN1 encoded binary ACF.
+     * @param size      The size of the ASN1 encoded binary ACF.
+     * @param auth      The user auth value to populate.
+     * @param type      The ACF type value to populate.
+     * @param expires   The ACF expiration date
+     * @param replay    The current and updated replay id value.
+     * @param action    The type of action to perform with the ACF.
+     * @param password  A pointer to a password for authentication.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int getAuth(const uint8_t* acf, size_t size, std::string& auth,
+                        unsigned int& type, std::string& expires,
+                        uint64_t& replay, TargetedAcfAction action,
+                        const char* password) = 0;
+
+    /**
+     * Retrieve the current replay id value.
+     * @brief Retrieve the replay id.
+     *
+     * @param replay    The replay id value to populate.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int retrieveReplayId(uint64_t& replay) = 0;
+
+    /**
+     * Store the updated replay id value.
+     * @brief Store the replay id.
+     *
+     * @param replay    The replay id value to populate.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int storeReplayId(uint64_t replay) = 0;
+
+    /**
+     * Reset the admin account using the associated user auth code.
+     * @brief Reset the admin account.
+     *
+     * @param auth  The associated user auth code.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int resetAdmin(const std::string& auth) = 0;
+
+    /**
+     * Remove the previously stored ACF.
+     * @brief Remove ACF.
+     */
+    virtual void removeAcf() = 0;
+
+    /**
+     * Install the new ACF.
+     * @brief Install ACF.
+     *
+     * @param acf       A pointer to an ASN1 encoded binary ACF.
+     * @param size      The size of the ASN1 encoded binary ACF.
+     *
+     * @return A non-zero error value or zero on success.
+     */
+    virtual int installAcf(const uint8_t* acf, size_t size) = 0;
+};


### PR DESCRIPTION
Add support for targeted ACF which leverages
ACF V2 in new ibm-acf subproject ce-login.
Much of the ACF V1 code was rewritten in
order to remove redundant code in ibm-acf
and phosphor-certificate-manager and to
to be more in line with ACF V2 requirements
and to properly leverage the ce-login
libraries. This support is made available
to other components, including phosphor-
certificate-manager, as dependency tacf.
Service ACF V1 is still supported.