### PR TITLE
build: handle usrmerge

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,5 +77,5 @@ else
   incdir = []
   subdir('src')
 
-  library('pam_ibmacf', sources, include_directories : incdir, pic : true, name_prefix : '', dependencies : deps, install : true, install_dir : '/lib/security')
+  library('pam_ibmacf', sources, include_directories : incdir, pic : true, name_prefix : '', dependencies : deps, install : true, install_dir : get_option('libdir') / 'security')
 endif


### PR DESCRIPTION
When building for merged-usr systems, the location of libdir might be in `/usr/lib`.  We should rely on the passed in `${libdir}` for installation rather than hard-coding as `/lib/security`

Change-Id: I88549455d1f17ad40d9b2953559408261b623f16