### PR TITLE
Update to resolve compile issues on older compilers

### DIFF
--- a/subprojects/ce-login/cli/CliUtils.cpp
+++ b/subprojects/ce-login/cli/CliUtils.cpp
@@ -135,7 +135,7 @@ bool cli::generateEtcPasswdHash(const char* pwParm, const std::size_t pwLenParm,
     if(sSuccess)
     {
         sStdOut.erase(std::remove(sStdOut.begin(), sStdOut.end(), '\n'),
-                      sStdOut.cend());
+                      sStdOut.end());
         hashParm = sStdOut;
     }
 


### PR DESCRIPTION
due to std::basic_string<char>::erase requiring const for both parameters  or non-const for both 
this change is needed to compile on older compilers, specifically RHEL7