### PR TITLE
meson: upgrade required meson and use c++23

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project('pam_ibmacf',
         'c' ,
         'cpp',
-        default_options : ['cpp_std=c++20'],
-        meson_version : '>=0.56.0')
+        default_options : ['cpp_std=c++23'],
+        meson_version : '>=1.1.1')
 
 cxx = meson.get_compiler('cpp')
 


### PR DESCRIPTION
This are now required to build against upstream code.

This is in prep for getting pNext/P11 rebased with upstream.