### PR TITLE
Remove vector from CeLoginUtil

### DIFF
--- a/subprojects/ce-login/celogin/src/CeLoginUtil.cpp
+++ b/subprojects/ce-login/celogin/src/CeLoginUtil.cpp
@@ -504,8 +504,8 @@ CeLogin::CeLoginRc CeLogin::getServiceAuthorityFromFrameworkEc(
 }
 
 CeLogin::CeLoginRc CeLogin::createSignature(EVP_PKEY* privateKeyParm, const EVP_MD* mdParm,
-                                            const std::vector<uint8_t>& digestParm,
-                                            std::vector<uint8_t>& generatedSignatureParm,
+                                            const uint8_t* digestParm, size_t digestParmSize,
+                                            uint8_t* generatedSignatureParm,
                                             size_t& signatureSizeParm)
 {
     CeLoginRc sRc = CeLoginRc::Success;
@@ -530,16 +530,17 @@ CeLogin::CeLoginRc CeLogin::createSignature(EVP_PKEY* privateKeyParm, const EVP_
     if (1 == sResult)
     {
         // This call calculates the final signature length
+        size_t sCalculatedSignatureSize = 0;
         sResult =
-            EVP_PKEY_sign(sCtx, NULL, &signatureSizeParm,
-                            digestParm.data(), digestParm.size());
+            EVP_PKEY_sign(sCtx, NULL, &sCalculatedSignatureSize,
+                            digestParm, digestParmSize);
         if ((1 == sResult) &&
-            (generatedSignatureParm.size() == signatureSizeParm))
+            (sCalculatedSignatureSize == signatureSizeParm))
         {
             // This call creates the signature
             sResult = EVP_PKEY_sign(
-                sCtx, generatedSignatureParm.data(), &signatureSizeParm,
-                digestParm.data(), digestParm.size());
+                sCtx, generatedSignatureParm, &signatureSizeParm,
+                digestParm, digestParmSize);
         }
         else
         {

--- a/subprojects/ce-login/celogin/src/CeLoginUtil.h
+++ b/subprojects/ce-login/celogin/src/CeLoginUtil.h
@@ -5,7 +5,6 @@
 #include <openssl/obj_mac.h>
 #include <openssl/sha.h>
 #include <openssl/evp.h>
-#include <vector>
 
 #ifndef _CELOGINUTIL_H
 #define _CELOGINUTIL_H
@@ -78,13 +77,29 @@ CeLoginRc
                                        const uint64_t frameworkEcLengthParm,
                                        ServiceAuthority& authParm);
 
+/// @brief Generic wrapper for verifying a signature with OpenSSL
+/// @param[in] publicKeyParm input public key to verify the signature with
+/// @param[in] mdTypeParm message digest type
+/// @param[in] signatureParm signature data to verify
+/// @param[in] signatureLengthParm signature data length
+/// @param[in] digestParm input digest
+/// @param[in] digestLengthParm input digest length
+/// @return CeLoginRc
 CeLoginRc verifySignature(EVP_PKEY* publicKeyParm, const EVP_MD* mdTypeParm, 
                           const uint8_t* signatureParm, size_t signatureLengthParm,
                           const uint8_t* digestParm, size_t digestLengthParm);
 
+/// @brief Generic wrapper for creating a signature with OpenSSL  
+/// @param[in] privateKeyParm input private key to create the signature with
+/// @param[in] mdParm message digest type
+/// @param[in] digestParm input digest
+/// @param[in] digestParmLength length of input digest buffer
+/// @param[out] generatedSignatureParm output signature buffer
+/// @param[inout] signatureSizeParm input signature buffer size, output generated signature size
+/// @return CeLoginRc
 CeLoginRc createSignature(EVP_PKEY* privateKeyParm, const EVP_MD* mdParm,
-                          const std::vector<uint8_t>& digestParm,
-                          std::vector<uint8_t>& generatedSignatureParm,
+                          const uint8_t* digestParm, size_t digestParmLength,
+                          uint8_t* generatedSignatureParm,
                           size_t& signatureSizeParm);
 }; // namespace CeLogin
 

--- a/subprojects/ce-login/cli/CliCeLoginV1.cpp
+++ b/subprojects/ce-login/cli/CliCeLoginV1.cpp
@@ -271,11 +271,11 @@ CeLogin::CeLoginRc CeLogin::createCeLoginAcfV1Signature(
     // TODO: Verify size matches expected size
     if (sPrivateKey)
     {
-        size_t sJsonSignatureSize = 0;
         generatedSignatureParm =
             std::vector<uint8_t>((EVP_PKEY_bits(sPrivateKey) + 7) / 8);
+        size_t sJsonSignatureSize = generatedSignatureParm.size();
         sRc = createSignature(sPrivateKey, EVP_sha512(),
-                              jsonDigestParm, generatedSignatureParm,
+                              jsonDigestParm.data(), jsonDigestParm.size(), generatedSignatureParm.data(),
                               sJsonSignatureSize);
     }
     else


### PR DESCRIPTION
Made a mistake and added the standard vector library to a file we import in PHYP (as we don't have STL support). This just changes one CeLoginUtil function to use pointers rather than vectors.