### PR TITLE
Reenable service user when ACF upload

### DIFF
--- a/src/tacf/tacf.hpp
+++ b/src/tacf/tacf.hpp
@@ -39,6 +39,7 @@ constexpr auto serialNumberEmpty = "       ";
 constexpr auto serialNumberUnset = "UNSET";
 
 constexpr auto adminName = "admin";
+constexpr auto serviceName = "service";
 
 constexpr auto privilegeAdmin = "priv-admin";
 constexpr auto privilegeUser  = "priv-user";
@@ -371,7 +372,15 @@ class Tacf : TargetedAcf
             return tacfFail;
         }
 
-        return writeFile(acf, size, acfFilePath);
+        int rc = writeFile(acf, size, acfFilePath);
+
+        // Enable the service user account using dbus interface.
+        TacfDbus().enableUser(serviceName);
+
+        // Unlock service user account using dbus interface.
+        TacfDbus().unlockUser(serviceName);
+
+        return rc;
     }
 
     /**


### PR DESCRIPTION
This changes the ACF upload function.  For a successful upload of a service login ACF, the service user is re-enabled and their password lockout is unlocked.

Tested: Success via QEMU
Locked service user acount via Redfish API and locked out the password attempts (by giving 5 bad login attempts), then uploaded the ACF, logged in successfully, and observed both conditions were cleared.

```
curl -k -H "X-Auth-Token: $TOKEN" -X PATCH -d '{"Enabled":false}' https://${bmc}/redfish/v1/AccountService/Accounts/service
for n in {1..5}; do
 curl -k -H "Content-Type: application/json" -X POST https://${bmc}/login -d '{"username": "service", "password": "A-BAD-password-"}'
done
curl -k -H "X-Auth-Token: $TOKEN" -X GET https://${bmc}/redfish/v1/AccountService/Accounts/service
```

Validate the service user account properties: Enabled:false and Locked:true
Upload an ACF, login, revalidate service user account properties