### PR TITLE
Improve ACF install error reporting

### DIFF
--- a/src/tacf/tacf.hpp
+++ b/src/tacf/tacf.hpp
@@ -215,7 +215,7 @@ class Tacf : TargetedAcf
 
         // Process ACF using auth provider with each key.
         TacfCelogin authProvider;
-        int authRc = CeLogin::CeLoginRc::Failure;
+        int retcode = CeLogin::CeLoginRc::SignatureNotValid;
 
         for (auto pathname : keyring)
         {
@@ -226,7 +226,7 @@ class Tacf : TargetedAcf
                 continue;
             }
 
-            int authRc;
+            int authRc = CeLogin::CeLoginRc::Failure;
             uint64_t expireTime = 0;
 
             // If action is verify.
@@ -265,9 +265,16 @@ class Tacf : TargetedAcf
                 // Return success.
                 return tacfSuccess;
             }
+
+            // The best return code may not be the last signature checked.
+            // SignatureNotValid is less interesting than other failures.
+            if (authRc != CeLogin::CeLoginRc::SignatureNotValid)
+            {
+                retcode = authRc;
+            }
         }
         // Or return error code.
-        return authRc;
+        return retcode;
     }
 
     /**


### PR DESCRIPTION
This fixes an issue where the authRc variable was shadowed in the ACF install path so it was not set to any meaningful value.

This improves the error code produced by the ACF install path.  The main observation is that multiple public keys are attempted and all but one of them will fail with CeLoginRc::RcBase::SignatureNotValid.  That is a valid error code, but errors from keys where the signature was valid should take precedence.  For example, consider when the second key is valid but the ACF is expired: the SignatureNotValid from the third key should not mask this more significant error code.

Tested: Yes
Scenarios: valid ACF installed, incorrect signature, expired ACF. The caller writes the error code into a journal entry.