### PR TITLE
Do not remove ACF when installing targeted ACFs

### DIFF
--- a/src/tacf/targetedAcf.hpp
+++ b/src/tacf/targetedAcf.hpp
@@ -77,12 +77,6 @@ class TargetedAcf
                         {
                             // Reset admin account.
                             rc = resetAdmin(auth);
-
-                            if (!rc)
-                            {
-                                // And remove old ACF.
-                                removeAcf();
-                            }
                         }
 
                         // Or if ACF type is service.


### PR DESCRIPTION
This changes the code for the "targeted ACF" design so successfully installing a targeted ACF (such as reset admin user) does not remove any "service login" ACF.  Specifically, installing an "admin reset" ACF does not invalidate the service user's login credentials.  All other aspects of the design remain the same.

Tested:
The steps are:
1. Install a "service login" ACF (and ensure it works).
2. Install an "admin reset" ACF (and ensure it was effective).
3. Validate the service user can login using the credentials from step 1.