### PR TITLE
Add service authority output to resource dump ACF flows

### DIFF
--- a/subprojects/ce-login/celogin/include/CeLogin.h
+++ b/subprojects/ce-login/celogin/include/CeLogin.h
@@ -223,6 +223,7 @@ struct AcfUserFields
         {
             char mResourceDump[MaxAsciiScriptFileLength];
             uint64_t mResourceDumpLength;
+            ServiceAuthority mAuth;
         } mResourceDumpFields;
 
         struct

--- a/subprojects/ce-login/celogin/src/CeLoginJson.cpp
+++ b/subprojects/ce-login/celogin/src/CeLoginJson.cpp
@@ -750,10 +750,9 @@ CeLoginRc ParseResourceDumpFields(const JsmnUtils::JsmnState& jsmnStateParm,
 
     if (CeLoginRc::Success == sRc)
     {
-        ServiceAuthority sIgnoredAuth;
         sRc = ParseCommonAcfFields(
             jsmnStateParm, decodedJsonParm.mExpirationDate, serialNumberParm,
-            serialNumberLengthParm, sIgnoredAuth);
+            serialNumberLengthParm, decodedJsonParm.mRequestedAuthority);
     }
 
     // Copy out resourcedump field

--- a/subprojects/ce-login/celogin/src/CeLoginV2.cpp
+++ b/subprojects/ce-login/celogin/src/CeLoginV2.cpp
@@ -501,6 +501,8 @@ static CeLoginRc checkAuthorizationAndGetAcfUserFieldsV2Internal(
                        sJsonData->mAsciiScriptFileLength);
                 userFieldsParm.mTypeSpecificFields.mResourceDumpFields
                     .mResourceDumpLength = sJsonData->mAsciiScriptFileLength;
+                userFieldsParm.mTypeSpecificFields.mResourceDumpFields.mAuth =
+                    sJsonData->mRequestedAuthority;
             }
         }
         else if (CeLogin::AcfType_BmcShell == sJsonData->mType)

--- a/subprojects/ce-login/cli/CliUnitTest.cpp
+++ b/subprojects/ce-login/cli/CliUnitTest.cpp
@@ -2495,6 +2495,10 @@ UnitTestResult ut_acf_resource_dump_v2()
                     .mResourceDumpLength)),
             sHsfArgsV2.mScript);
     DO_TEST(sResult, sFields.mExpirationTime > 0, sFields.mExpirationTime);
+    DO_TEST(sResult,
+            sFields.mTypeSpecificFields.mResourceDumpFields.mAuth ==
+                ServiceAuth_CE,
+            sFields.mTypeSpecificFields.mResourceDumpFields.mAuth);
 
     // Any input for replay ID that isn't exactly equal should fail
     sFields.clear();


### PR DESCRIPTION
PHYP still needs to parse the requested service authority that goes along with a resource dump ACF, this change adds this output into the AcfUserFields structure for the resource dump ACF type.