### PR TITLE
create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,234 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2025-03-25T13:15:32Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "7271c43b3c68be09ed650be9d80245967f898d82",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 113,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/tacf/tacfCelogin.hpp": [
+      {
+        "hashed_secret": "186d28c0edae5d49cad741e1f9ca971cb1146a6b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 126,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/tacf/tacfSpw.hpp": [
+      {
+        "hashed_secret": "df58248c414f342c81e056b40bee12d17a08bf61",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "subprojects/ce-login/cli/CliCeLoginV2.cpp": [
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "subprojects/ce-login/cli/CliCreateHsf.cpp": [
+      {
+        "hashed_secret": "6e948ea7dc1d1054258e531dbdc501f258883cec",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 126,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "subprojects/ce-login/cli/CliUnitTest.cpp": [
+      {
+        "hashed_secret": "ffb6b0df52406a12074ca094831141bccab2f455",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2202,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4fcaa4233af61481db420fde3e91981653693dad",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2246,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dc8df65c7febf6b53297a12416a98981b81044f2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2263,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "335119a0c9c84328fffcc26be2767604a67765d1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2418,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "subprojects/ce-login/cli/CliUtils.cpp": [
+      {
+        "hashed_secret": "b224e2fb20f87d2807755dec40a3c2c0117a9dc6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 274,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1736efa6014c126079072c25234d34861c567f77",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 277,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c9a5d7c0244f2128e4a4a35b2006a4649f55a638",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 281,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5c37425985c5dc7dfbb6335c5a43b59e6e0877c9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 288,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "subprojects/ce-login/subprojects/jsmn.wrap": [
+      {
+        "hashed_secret": "079a19194a0bf88b76c7d560f512aa90c811373e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "subprojects/ce-login/uploadDevAcf": [
+      {
+        "hashed_secret": "7271c43b3c68be09ed650be9d80245967f898d82",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "subprojects/pam_wrapper.wrap": [
+      {
+        "hashed_secret": "9b6f130219ad33caf461d4f4d6f8557e0acbcae9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
  https://github.com/IBM/detect-secrets