### PR TITLE
ibm-acf: Add PAM authentication without replay ID validation

### DIFF
--- a/src/tacf/tacfCelogin.hpp
+++ b/src/tacf/tacfCelogin.hpp
@@ -38,9 +38,10 @@ class TacfCelogin
 
         CeLogin::AcfUserFields acfUserFields;
 
-        // Authenticate with password.
+        // Authenticate with password using PAM-specific function
+        // This skips replay ID validation for PAM authentication
         CeLogin::CeLoginRc authRc =
-            CeLogin::checkAuthorizationAndGetAcfUserFieldsV2(
+            CeLogin::checkAuthorizationAndGetAcfUserFieldsV2ForPAM(
                 acf, acfSize, password, strlen(password), timestamp, pubkey,
                 pubkeySize, serial.data(), serial.size(), replayId,
                 acfUserFields);

--- a/subprojects/ce-login/celogin/include/CeLogin.h
+++ b/subprojects/ce-login/celogin/include/CeLogin.h
@@ -379,6 +379,42 @@ CeLoginRc checkAuthorizationAndGetAcfUserFieldsV2(
     const char* serialNumberParm, const uint64_t serialNumberLengthParm,
     const uint64_t currentReplayIdParm, AcfUserFields& userFieldsParm);
 
+/** @brief PAM-specific authentication without replay ID validation
+ *
+ *  This function is specifically for PAM authentication use cases where
+ *  replay ID validation should be skipped. Users can login with password
+ *  and service username without anti-replay validation checks.
+ *  All other validations (signature, expiration, serial number, password)
+ *  remain active.
+ *
+ *  @param accessControlFileParm a pointer to the ASN1 encoded binary ACF
+ *  @param accessControlFileLengthParm the byte length of the provided ACF
+ *  @param passwordParm a pointer to the provided password
+ *  @param passwordLengthParm the length of the provided password
+ *  @param timeSinceUnixEpochInSecondsParm the current system time encoded as a
+ * unix timestamp
+ *  @param publicKeyParm a pointer to the public key used to validate the
+ * signature over the ACF
+ *  @param publicKeyLengthParm the byte length of the provided public key
+ *  @param serialNumberParm a pointer to the serial number of the current system
+ *  @param serialNumberLengthParm the length of the provided serial number
+ *  @param currentReplayIdParm the current replay ID (ignored for validation)
+ *  @param userFieldsParm an instance of AcfUserFields which contains the data
+ * parsed from the ACF on successful execution.
+ *
+ *  @return A CeLoginRc indicating the result. CeLoginRc::Success indicates that
+ * the ACF is valid and the AcfUserFields has been populated with the relevant
+ * fields.
+ */
+CeLoginRc checkAuthorizationAndGetAcfUserFieldsV2ForPAM(
+    const uint8_t* accessControlFileParm,
+    const uint64_t accessControlFileLengthParm, const char* passwordParm,
+    const uint64_t passwordLengthParm,
+    const uint64_t timeSinceUnixEpochInSecondsParm,
+    const uint8_t* publicKeyParm, const uint64_t publicKeyLengthParm,
+    const char* serialNumberParm, const uint64_t serialNumberLengthParm,
+    const uint64_t currentReplayIdParm, AcfUserFields& userFieldsParm);
+
 #else
 
 /** @brief PowerVM interface for checkAuthorizationAndGetAcfUserFieldsV2

--- a/subprojects/ce-login/celogin/src/CeLoginV2.cpp
+++ b/subprojects/ce-login/celogin/src/CeLoginV2.cpp
@@ -100,42 +100,37 @@ static CeLoginRc validateAndParseAcfV2(
 static CeLogin::CeLoginRc doFullReplayValidation(
     const CeLogin::AcfType acfTypeParm, const bool replayIdPresent,
     const uint64_t currentPersistedReplayIdParm, const uint64_t acfReplayIdParm,
-    uint64_t& updatedReplayIdParm)
+    uint64_t& updatedReplayIdParm, bool strictValidity)
 {
-    CeLoginRc sRc = CeLoginRc::Success;
-
-    if (replayIdPresent)
-    {
-        // The validity checks here depend on ACF type
-        // Since a service ACF may be validated more than once, we will tolerate
-        // a replay ID that is >= the persisted value. All other use cases
-        // (today) require a strict inequality
-        if (CeLogin::AcfType_Service == acfTypeParm)
-        {
-            if (acfReplayIdParm < currentPersistedReplayIdParm)
-            {
-                sRc = CeLoginRc::InvalidReplayId;
-            }
-        }
-        else
-        {
-            if (acfReplayIdParm <= currentPersistedReplayIdParm)
-            {
-                sRc = CeLoginRc::InvalidReplayId;
-            }
-        }
-
-        if (CeLoginRc::Success == sRc)
-        {
-            updatedReplayIdParm = acfReplayIdParm;
-        }
-    }
-    else
+    if (!replayIdPresent)
     {
         updatedReplayIdParm = currentPersistedReplayIdParm;
+        return CeLoginRc::Success;
     }
-
-    return sRc;
+    if (strictValidity)
+    {
+        if (acfReplayIdParm <= currentPersistedReplayIdParm)
+        {
+            return CeLoginRc::InvalidReplayId;
+        }
+        updatedReplayIdParm = acfReplayIdParm;
+        return CeLoginRc::Success;
+    }
+    if (CeLogin::AcfType_Service == acfTypeParm)
+    {
+        if (acfReplayIdParm < currentPersistedReplayIdParm)
+        {
+            return CeLoginRc::InvalidReplayId;
+        }
+        updatedReplayIdParm = acfReplayIdParm;
+        return CeLoginRc::Success;
+    }
+    if (acfReplayIdParm <= currentPersistedReplayIdParm)
+    {
+        return CeLoginRc::InvalidReplayId;
+    }
+    updatedReplayIdParm = acfReplayIdParm;
+    return CeLoginRc::Success;
 }
 
 CeLoginRc CeLogin::extractACFMetadataV2(
@@ -331,7 +326,7 @@ CeLoginRc CeLogin::verifyACFForBMCUploadV2(
         sRc = doFullReplayValidation(
             sJsonData->mType, sJsonData->mReplayInfo.mReplayIdPresent,
             currentReplayIdParm, sJsonData->mReplayInfo.mReplayId,
-            updatedReplayIdParm);
+            updatedReplayIdParm, true);
     }
 
     if (CeLoginRc::Success == sRc)
@@ -593,6 +588,32 @@ CeLoginRc CeLogin::checkAuthorizationAndGetAcfUserFieldsV2(
 
     return sRc;
 }
+
+CeLoginRc CeLogin::checkAuthorizationAndGetAcfUserFieldsV2ForPAM(
+    const uint8_t* accessControlFileParm,
+    const uint64_t accessControlFileLengthParm, const char* passwordParm,
+    const uint64_t passwordLengthParm,
+    const uint64_t timeSinceUnixEpochInSecondsParm,
+    const uint8_t* publicKeyParm, const uint64_t publicKeyLengthParm,
+    const char* serialNumberParm, const uint64_t serialNumberLengthParm,
+    const uint64_t currentReplayIdParm, AcfUserFields& userFieldsParm)
+{
+    bool sHasReplayId = false;
+    uint64_t sAcfReplayId = 0;
+
+    CeLoginRc sRc = checkAuthorizationAndGetAcfUserFieldsV2Internal(
+        accessControlFileParm, accessControlFileLengthParm, passwordParm,
+        passwordLengthParm, timeSinceUnixEpochInSecondsParm, publicKeyParm,
+        publicKeyLengthParm, serialNumberParm, serialNumberLengthParm,
+        sHasReplayId, sAcfReplayId, userFieldsParm);
+
+    // PAM authentication: Skip replay ID validation entirely
+    // Users can login with password and service username without anti-replay
+    // checks All other validations (signature, expiration, serial number,
+    // password) remain active
+
+    return sRc;
+}
 #else
 CeLoginRc CeLogin::checkAuthorizationAndGetAcfUserFieldsV2ForPowerVM(
     const uint8_t* accessControlFileParm,
@@ -625,7 +646,7 @@ CeLoginRc CeLogin::checkAuthorizationAndGetAcfUserFieldsV2ForPowerVM(
         {
             sRc = doFullReplayValidation(userFieldsParm.mType, sHasReplayId,
                                          currentReplayIdParm, sAcfReplayId,
-                                         updatedReplayIdParm);
+                                         updatedReplayIdParm, false);
         }
     }
 


### PR DESCRIPTION
Add a new PAM-specific authentication function and refactor replay ID validation to support both strict and relaxed validation modes.

Changes include:

1. New PAM authentication function:
   - Add checkAuthorizationAndGetAcfUserFieldsV2ForPAM() that skips replay ID validation entirely for PAM authentication use cases
   - Enables service user to login multiple times with same ACF

2. Refactored replay validation logic:
   - Add strictValidity parameter to doFullReplayValidation()
   - Strict mode (BMC upload): Requires replay ID > persisted value
   - Relaxed mode (PowerVM): Allows replay ID >= persisted value for service ACFs to support multiple authentications

3. Updated callers:
   - verifyACFForBMCUploadV2() uses strict validation (true)
   - checkAuthorizationAndGetAcfUserFieldsV2ForPowerVM() uses relaxed validation (false)
   - TacfCelogin::authenticate() now calls PAM-specific function

Security validations that remain active for PAM authentication:
- Cryptographic signature verification
- ACF expiration checking
- Serial number validation
- Password hash verification

The existing validation functions remain unchanged for non-PAM use cases, ensuring replay ID checks are still enforced for ACF upload and other operations.

Tested: Service user can login via PAM with valid ACF and password
        without replay ID restrictions.