### PR TITLE
tacf: Remove automatic ACF deletion after admin reset

### DIFF
--- a/src/tacf/targetedAcf.hpp
+++ b/src/tacf/targetedAcf.hpp
@@ -77,12 +77,6 @@ class TargetedAcf
                             case acfTypeAdminReset:
                             {
                                 rc = resetAdmin(auth);
-
-                                if (!rc)
-                                {
-                                    // And remove old ACF.
-                                    removeAcf();
-                                }
                             }
                             break;
                             case acfTypeService:


### PR DESCRIPTION
Remove the code that automatically deletes the ACF file after a successful admin reset operation. This allows the ACF to persist after admin reset, which may be required for certain operational scenarios.

The removeAcf() call has been removed from the acfTypeAdminReset case in the TargetedAcf class.